### PR TITLE
Fix: CF7 photo upload TypeError + output buffer to protect JSON respo…

### DIFF
--- a/admin/review-form.php
+++ b/admin/review-form.php
@@ -274,15 +274,33 @@ function reviewfic_cf7_on_submit( $contact_form ) {
     }
 
     // Photo upload
+    // CF7 5.x uploaded_files() may return a string path or an array of paths.
+    // Passing an array to file_exists() throws a TypeError in PHP 8+, which
+    // corrupts CF7's JSON response and leaves the form stuck on the spinner.
     $photo_field    = sanitize_text_field( $field_map['photo'] ?? '' );
     $uploaded_files = $submission->uploaded_files();
-    $tmp_path       = $uploaded_files[ $photo_field ] ?? '';
-    if ( $photo_field && $tmp_path && file_exists( $tmp_path ) ) {
+    $tmp_raw        = $photo_field ? ( $uploaded_files[ $photo_field ] ?? null ) : null;
+    // Normalise to a single string path regardless of CF7 version.
+    if ( is_array( $tmp_raw ) ) {
+        $tmp_path = (string) ( reset( $tmp_raw ) ?: '' );
+    } elseif ( is_string( $tmp_raw ) ) {
+        $tmp_path = $tmp_raw;
+    } else {
+        $tmp_path = '';
+    }
+    if ( $tmp_path !== '' && file_exists( $tmp_path ) ) {
         require_once ABSPATH . 'wp-admin/includes/image.php';
         require_once ABSPATH . 'wp-admin/includes/file.php';
         require_once ABSPATH . 'wp-admin/includes/media.php';
-        $attachment_id = media_handle_sideload( array( 'name' => basename( $tmp_path ), 'tmp_name' => $tmp_path ), $post_id );
-        if ( $attachment_id && ! is_wp_error( $attachment_id ) ) {
+        // Buffer output so any PHP notices from the sideload helpers cannot
+        // corrupt CF7's JSON AJAX / REST API response.
+        ob_start();
+        $attachment_id = media_handle_sideload(
+            array( 'name' => basename( $tmp_path ), 'tmp_name' => $tmp_path ),
+            $post_id
+        );
+        ob_end_clean();
+        if ( ! is_wp_error( $attachment_id ) ) {
             update_post_meta( $post_id, 'reviewfic_reviewer_photo', $attachment_id );
         }
     }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hasanet, themefic
 Tags: testimonials, reviews, star rating, customer reviews, social proof
 Requires at least: 5.4
 Tested up to: 6.9
-Stable tag: 1.2.35
+Stable tag: 1.2.36
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -260,6 +260,10 @@ Yes. Go to **Reviewfic → Form Integrations** and select the relevant tab. Enab
 6. Dark and Centered templates
 
 == Changelog ==
+
+= 1.2.36 =
+* Fix: CF7 photo upload now correctly handles CF7 5.x+ where uploaded_files() returns an array of paths instead of a single string — previously caused a PHP 8 TypeError that corrupted CF7's JSON response and left the form stuck on the loading spinner.
+* Fix: Wrapped media_handle_sideload in an output buffer so any PHP notices from WP image helpers cannot bleed into CF7's AJAX / REST API JSON response.
 
 = 1.2.28 =
 * New: WooCommerce integration — post-purchase review request email with configurable delay (0–14 days).

--- a/reviewfic.php
+++ b/reviewfic.php
@@ -3,7 +3,7 @@
 Plugin Name: Reviewfic – Testimonial Slider, Testimonial Grid & Customer Reviews
 Plugin URI: https://themefic.com/reviewfic/
 Description: A plugin to create and manage client reviews with custom post types and shortcodes.
-Version: 1.2.35
+Version: 1.2.36
 Author: Themefic
 Author URI: https://themefic.com
 Text Domain: reviewfic


### PR DESCRIPTION
…nse (v1.2.36)

- uploaded_files() in CF7 5.x+ returns an array of paths, not a string. Passing that array to file_exists() causes a PHP 8 TypeError (fatal), which corrupts CF7's AJAX/REST JSON response and leaves the form stuck on the loading spinner while the review data (minus photo) is saved.
- Normalise the return value to a single string path before calling file_exists() or media_handle_sideload().
- Wrap media_handle_sideload in ob_start/ob_end_clean so any PHP notices from WP image helpers cannot bleed into CF7's JSON response.