### PR TITLE
v1.2.37: Tourfic integration

### DIFF
--- a/admin/form-integrations.php
+++ b/admin/form-integrations.php
@@ -412,6 +412,12 @@ function rwf_integrations_page() {
             'forms'  => array(),
             'id_hint' => '',
         ),
+        'tourfic' => array(
+            'label'  => 'Tourfic',
+            'active' => defined( 'TF_VERSION' ) && class_exists( 'WooCommerce' ),
+            'forms'  => array(),
+            'id_hint' => '',
+        ),
     );
     ?>
     <div class="wrap rwf-ie-wrap">
@@ -477,6 +483,41 @@ function rwf_integrations_page() {
                 <a href="<?php echo esc_url( admin_url( 'edit.php?post_type=reviewfic_reviews&page=reviewfic-woocommerce' ) ); ?>" class="button button-primary rwf-ie-btn">
                     <span class="dashicons dashicons-admin-settings"></span>
                     <?php esc_html_e( 'Configure WooCommerce Settings', 'reviewfic' ); ?>
+                </a>
+            </div>
+
+        <?php elseif ( $active_tab === 'tourfic' ) :
+            $tf = get_option( 'reviewfic_tf_settings', array() );
+            $en_tf      = ( $tf['enabled']         ?? '0' ) === '1';
+            $rep_sec    = ( $tf['replace_section']  ?? '0' ) === '1';
+            $auto_tag   = ( $tf['auto_tag']         ?? '1' ) === '1';
+            $delay      = $tf['delay_days']         ?? '2';
+            $pg_id      = intval( $tf['review_page'] ?? 0 );
+            $pg_name    = $pg_id ? get_the_title( $pg_id ) : __( 'Not set', 'reviewfic' );
+        ?>
+            <div class="rwf-ie-card" style="max-width:680px;">
+                <div class="rwf-ie-card-header">
+                    <span class="dashicons dashicons-location-alt rwf-ie-card-icon"></span>
+                    <div>
+                        <h2><?php esc_html_e( 'Tourfic Integration', 'reviewfic' ); ?></h2>
+                        <p><?php esc_html_e( 'Current Tourfic settings summary.', 'reviewfic' ); ?></p>
+                    </div>
+                </div>
+                <table class="rwf-ie-schema" style="margin-bottom:20px;">
+                    <tr><td><strong><?php esc_html_e( 'Review Request Emails', 'reviewfic' ); ?></strong></td>
+                        <td><?php echo $en_tf ? '<span style="color:#0E9F6E;font-weight:600;">&#10003; Enabled</span>' : '<span style="color:#6b7280;">&#10007; Disabled</span>'; ?></td></tr>
+                    <tr><td><strong><?php esc_html_e( 'Send Delay', 'reviewfic' ); ?></strong></td>
+                        <td><?php echo esc_html( $delay == '0' ? __('Immediately','reviewfic') : $delay . ' ' . __('day(s) after completion','reviewfic') ); ?></td></tr>
+                    <tr><td><strong><?php esc_html_e( 'Review Landing Page', 'reviewfic' ); ?></strong></td>
+                        <td><?php echo esc_html( $pg_name ); ?></td></tr>
+                    <tr><td><strong><?php esc_html_e( 'Replace Tourfic Review Section', 'reviewfic' ); ?></strong></td>
+                        <td><?php echo $rep_sec ? '<span style="color:#0E9F6E;font-weight:600;">&#10003; Enabled</span>' : '<span style="color:#6b7280;">&#10007; Disabled</span>'; ?></td></tr>
+                    <tr><td><strong><?php esc_html_e( 'Auto-Tag by Service', 'reviewfic' ); ?></strong></td>
+                        <td><?php echo $auto_tag ? '<span style="color:#0E9F6E;font-weight:600;">&#10003; Enabled</span>' : '<span style="color:#6b7280;">&#10007; Disabled</span>'; ?></td></tr>
+                </table>
+                <a href="<?php echo esc_url( admin_url( 'edit.php?post_type=reviewfic_reviews&page=reviewfic-tourfic' ) ); ?>" class="button button-primary rwf-ie-btn">
+                    <span class="dashicons dashicons-admin-settings"></span>
+                    <?php esc_html_e( 'Configure Tourfic Settings', 'reviewfic' ); ?>
                 </a>
             </div>
 

--- a/admin/review-form.php
+++ b/admin/review-form.php
@@ -118,6 +118,14 @@ function reviewfic_form_shortcode( $atts ) {
             if ( $rwf_product_id ) {
                 echo '<input type="hidden" name="rwf_product_id" value="' . esc_attr( $rwf_product_id ) . '">';
             }
+
+            // Pre-fill Tourfic service context from URL (set by Tourfic review request email)
+            $rwf_tf_service = intval( $_GET['rwf_tf_service'] ?? $_POST['rwf_tf_service_id'] ?? 0 );
+            $rwf_tf_type    = sanitize_key( $_GET['rwf_tf_type'] ?? $_POST['rwf_tf_type'] ?? '' );
+            if ( $rwf_tf_service ) {
+                echo '<input type="hidden" name="rwf_tf_service_id" value="' . esc_attr( $rwf_tf_service ) . '">';
+                echo '<input type="hidden" name="rwf_tf_type" value="' . esc_attr( $rwf_tf_type ) . '">';
+            }
             ?>
 
             <div class="rwf-form-row">

--- a/admin/templates/tourfic-reviews.php
+++ b/admin/templates/tourfic-reviews.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Reviewfic — Tourfic Review Section Template
+ *
+ * Returned by the `comments_template` filter (priority 20) when
+ * "Replace the Tourfic review section" is enabled. Renders Reviewfic
+ * review cards for the current hotel / tour / apartment listing,
+ * followed by a "Write a Review" CTA that links to the configured
+ * Reviewfic review landing page.
+ *
+ * This file is included by WordPress inside a proper post context
+ * (via the comments_template() call in the Tourfic template), so
+ * $post and $comments are available.
+ */
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+global $post;
+if ( ! $post ) return;
+
+$s              = rwf_tf_get_settings();
+$review_page_id = intval( $s['review_page'] );
+
+// Pull approved comments for this listing using the same args Tourfic uses
+$comments = get_comments( array(
+    'post_id' => $post->ID,
+    'status'  => 'approve',
+    'order'   => 'DESC',
+) );
+
+// ── Render review cards via Reviewfic ──────────────────────────────────────
+echo '<div class="rwf-tf-reviews-wrap">';
+
+if ( empty( $comments ) ) {
+    echo '<p class="rwf-tf-no-reviews">' . esc_html__( 'No reviews yet. Be the first to leave one!', 'reviewfic' ) . '</p>';
+} else {
+    $reviews = array();
+    foreach ( $comments as $comment ) {
+
+        // Tourfic stores sub-ratings in `tf_comment_meta` (associative array).
+        // Fall back to `tf_total_ratings` (pre-computed average) if present.
+        $total_rating = floatval( get_comment_meta( $comment->comment_ID, 'tf_total_ratings', true ) );
+        if ( ! $total_rating ) {
+            $sub_ratings = get_comment_meta( $comment->comment_ID, 'tf_comment_meta', true );
+            if ( is_array( $sub_ratings ) && ! empty( $sub_ratings ) ) {
+                $values = array_filter( array_map( 'floatval', $sub_ratings ) );
+                $total_rating = ! empty( $values ) ? array_sum( $values ) / count( $values ) : 5.0;
+            } else {
+                $total_rating = 5.0;
+            }
+        }
+
+        // Clamp to 1–5
+        $stars = max( 1, min( 5, round( $total_rating ) ) );
+
+        $reviews[] = array(
+            'title'   => '',
+            'content' => $comment->comment_content,
+            'stars'   => $stars,
+            'name'    => $comment->comment_author,
+            'meta'    => '',
+            'avatar'  => get_avatar_url( $comment->comment_author_email, array( 'size' => 96 ) ),
+            'time'    => human_time_diff( strtotime( $comment->comment_date ), current_time( 'timestamp' ) ) . ' ' . __( 'ago', 'reviewfic' ),
+        );
+    }
+
+    if ( function_exists( 'rwf_render_live_cards' ) ) {
+        echo rwf_render_live_cards( $reviews, array( // phpcs:ignore WordPress.Security.EscapeOutput
+            'columns'     => '3',
+            'template'    => '1',
+            'slider'      => 'no',
+            'show_avatar' => 'yes',
+        ), 'custom', get_bloginfo( 'name' ) );
+    }
+}
+
+// ── Write a Review CTA ────────────────────────────────────────────────────
+if ( $review_page_id ) {
+    $url = add_query_arg( array(
+        'rwf_tf_service' => $post->ID,
+        'rwf_tf_type'    => rwf_tf_type_from_post_type( $post->post_type ),
+    ), get_permalink( $review_page_id ) );
+    ?>
+    <div class="rwf-wc-write-review">
+        <a href="<?php echo esc_url( $url ); ?>" class="rwf-wc-review-btn">
+            <span class="dashicons dashicons-edit"></span>
+            <?php esc_html_e( 'Write a Review', 'reviewfic' ); ?>
+        </a>
+    </div>
+    <?php
+}
+
+echo '</div><!-- .rwf-tf-reviews-wrap -->';
+
+/**
+ * Map a Tourfic post type to its order type slug.
+ * Defined inline so the template is self-contained.
+ */
+function rwf_tf_type_from_post_type( $post_type ) {
+    $map = array(
+        'tf_hotel'     => 'hotel',
+        'tf_tours'     => 'tour',
+        'tf_apartment' => 'apartment',
+        'tf_carrental' => 'car',
+    );
+    return $map[ $post_type ] ?? '';
+}

--- a/admin/tourfic.php
+++ b/admin/tourfic.php
@@ -1,0 +1,455 @@
+<?php
+/**
+ * Reviewfic — Tourfic Integration
+ *
+ * Features:
+ *  1. Post-booking review request email (with configurable delay)
+ *  2. Replace Tourfic review section with Reviewfic cards (hotels, tours, apartments)
+ *  3. Auto-tag reviews by service type + name when submitted via review request link
+ *
+ * Settings stored in: reviewfic_tf_settings (array)
+ *
+ * Notes:
+ *  - Car rental review replacement is NOT supported: Tourfic embeds its car review
+ *    block directly in the template without calling comments_template(), so there
+ *    is no standard hook to intercept. Email + auto-tag still work for car bookings.
+ *  - Tourfic stores tour post IDs as `_tour_id` order item meta; hotel/apartment/car
+ *    use `_post_id`.
+ */
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+// Only load when both Tourfic and WooCommerce are active
+add_action( 'plugins_loaded', 'rwf_tf_init' );
+
+function rwf_tf_init() {
+    if ( ! defined( 'TF_VERSION' ) || ! class_exists( 'WooCommerce' ) ) return;
+
+    // Admin
+    add_action( 'admin_menu',             'rwf_tf_register_page' );
+    add_action( 'admin_post_rwf_save_tf', 'rwf_tf_save_settings' );
+
+    // Email scheduling — fires when a WooCommerce order containing a Tourfic booking completes
+    add_action( 'woocommerce_order_status_completed', 'rwf_tf_schedule_email' );
+    add_action( 'reviewfic_send_tf_review_email',     'rwf_tf_send_email' );
+
+    // Review section replacement — priority 20 runs after Tourfic's filter at priority 10
+    add_filter( 'comments_template', 'rwf_tf_replace_comments_template', 20 );
+
+    // Auto-tag by service name on form submit
+    add_action( 'reviewfic_after_form_submit', 'rwf_tf_auto_tag_service', 10, 2 );
+}
+
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function rwf_tf_get_settings() {
+    return wp_parse_args( get_option( 'reviewfic_tf_settings', array() ), array(
+        'enabled'       => '0',
+        'delay_days'    => '2',
+        'review_page'   => '',
+        'email_subject' => 'How was your experience with {site_name}?',
+        'email_body'    => "Hi {customer_name},\n\nThank you for your recent booking (#{order_id}) with {site_name}.\n\nWe'd love to hear what you think! Your feedback helps us improve and helps other travellers make better decisions.\n\nClick the button below to leave your review — it only takes a minute.\n\nThank you for choosing {site_name}!",
+        'replace_section' => '0',
+        'auto_tag'        => '1',
+    ) );
+}
+
+/**
+ * Get the Tourfic service (hotel / tour / apartment / car) from a WooCommerce order.
+ * Returns array with 'type' and 'post_id', or null if no Tourfic item found.
+ */
+function rwf_tf_get_service_from_order( $order ) {
+    foreach ( $order->get_items() as $item ) {
+        $order_type = $item->get_meta( '_order_type', true );
+        if ( ! in_array( $order_type, array( 'hotel', 'tour', 'apartment', 'car' ), true ) ) {
+            continue;
+        }
+        // Tours store their post ID under _tour_id; everything else uses _post_id
+        $post_id = ( 'tour' === $order_type )
+            ? intval( $item->get_meta( '_tour_id', true ) )
+            : intval( $item->get_meta( '_post_id', true ) );
+
+        if ( $post_id ) {
+            return array( 'type' => $order_type, 'post_id' => $post_id );
+        }
+    }
+    return null;
+}
+
+/** Type label used for auto-tag category prefix (e.g. "Hotel", "Tour") */
+function rwf_tf_type_label( $type ) {
+    $labels = array(
+        'hotel'     => __( 'Hotel',     'reviewfic' ),
+        'tour'      => __( 'Tour',      'reviewfic' ),
+        'apartment' => __( 'Apartment', 'reviewfic' ),
+        'car'       => __( 'Car',       'reviewfic' ),
+    );
+    return $labels[ $type ] ?? ucfirst( $type );
+}
+
+function rwf_set_html_mail_tf() { return 'text/html'; }
+
+
+// ══════════════════════════════════════════════════════════════════════════
+//  ADMIN SETTINGS PAGE
+// ══════════════════════════════════════════════════════════════════════════
+
+function rwf_tf_register_page() {
+    add_submenu_page(
+        'edit.php?post_type=reviewfic_reviews',
+        __( 'Tourfic', 'reviewfic' ),
+        __( 'Tourfic', 'reviewfic' ),
+        'manage_options',
+        'reviewfic-tourfic',
+        'rwf_tf_page'
+    );
+}
+
+function rwf_tf_save_settings() {
+    if ( ! current_user_can( 'manage_options' ) ) wp_die( 'Unauthorized' );
+    check_admin_referer( 'rwf_save_tf' );
+
+    $s = rwf_tf_get_settings();
+    $s['enabled']         = isset( $_POST['rwf_tf_enabled'] ) ? '1' : '0';
+    $s['delay_days']      = sanitize_text_field( wp_unslash( $_POST['rwf_delay_days']  ?? '2' ) );
+    $s['review_page']     = intval( $_POST['rwf_review_page'] ?? 0 );
+    $s['email_subject']   = sanitize_text_field( wp_unslash( $_POST['rwf_email_subject'] ?? '' ) );
+    $s['email_body']      = sanitize_textarea_field( wp_unslash( $_POST['rwf_email_body'] ?? '' ) );
+    $s['replace_section'] = isset( $_POST['rwf_replace_section'] ) ? '1' : '0';
+    $s['auto_tag']        = isset( $_POST['rwf_auto_tag'] ) ? '1' : '0';
+
+    update_option( 'reviewfic_tf_settings', $s );
+
+    wp_safe_redirect( add_query_arg( array(
+        'post_type' => 'reviewfic_reviews',
+        'page'      => 'reviewfic-tourfic',
+        'saved'     => '1',
+    ), admin_url( 'edit.php' ) ) );
+    exit;
+}
+
+function rwf_tf_page() {
+    $s     = rwf_tf_get_settings();
+    $saved = ! empty( $_GET['saved'] );
+    $pages = get_pages( array( 'post_status' => 'publish' ) );
+
+    $delay_options = array(
+        '0'  => __( 'Immediately on order completion', 'reviewfic' ),
+        '1'  => __( '1 day after order completion',   'reviewfic' ),
+        '2'  => __( '2 days after order completion',  'reviewfic' ),
+        '3'  => __( '3 days after order completion',  'reviewfic' ),
+        '5'  => __( '5 days after order completion',  'reviewfic' ),
+        '7'  => __( '7 days after order completion',  'reviewfic' ),
+        '14' => __( '14 days after order completion', 'reviewfic' ),
+    );
+    ?>
+    <div class="wrap rwf-ie-wrap">
+        <h1 class="wp-heading-inline"><?php esc_html_e( 'Tourfic Integration', 'reviewfic' ); ?></h1>
+        <hr class="wp-header-end">
+
+        <?php if ( $saved ) : ?>
+            <div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'Settings saved.', 'reviewfic' ); ?></p></div>
+        <?php endif; ?>
+
+        <?php if ( ! defined( 'TF_VERSION' ) ) : ?>
+            <div class="notice notice-warning"><p>
+                <?php esc_html_e( 'Tourfic is not installed or activated. These settings will have no effect until Tourfic is active.', 'reviewfic' ); ?>
+            </p></div>
+        <?php endif; ?>
+
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+            <?php wp_nonce_field( 'rwf_save_tf' ); ?>
+            <input type="hidden" name="action" value="rwf_save_tf">
+
+            <div class="rwf-wc-grid">
+
+                <!-- ── Post-Booking Email ── -->
+                <div class="rwf-ie-card">
+                    <div class="rwf-ie-card-header">
+                        <span class="dashicons dashicons-email-alt rwf-ie-card-icon"></span>
+                        <div>
+                            <h2><?php esc_html_e( 'Post-Booking Review Request', 'reviewfic' ); ?></h2>
+                            <p><?php esc_html_e( 'Automatically email customers after their booking is confirmed, asking them to leave a review.', 'reviewfic' ); ?></p>
+                        </div>
+                    </div>
+
+                    <div class="rwf-wc-field">
+                        <label class="rwf-wc-toggle-label">
+                            <input type="checkbox" name="rwf_tf_enabled" value="1" <?php checked( $s['enabled'], '1' ); ?>>
+                            <strong><?php esc_html_e( 'Enable review request emails', 'reviewfic' ); ?></strong>
+                        </label>
+                    </div>
+
+                    <div class="rwf-wc-field">
+                        <label><?php esc_html_e( 'Send Delay', 'reviewfic' ); ?></label>
+                        <select name="rwf_delay_days">
+                            <?php foreach ( $delay_options as $val => $label ) : ?>
+                                <option value="<?php echo esc_attr( $val ); ?>" <?php selected( $s['delay_days'], (string) $val ); ?>>
+                                    <?php echo esc_html( $label ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <div class="rwf-wc-field">
+                        <label><?php esc_html_e( 'Review Landing Page', 'reviewfic' ); ?></label>
+                        <select name="rwf_review_page">
+                            <option value=""><?php esc_html_e( '— Select a page with [reviewfic_form] —', 'reviewfic' ); ?></option>
+                            <?php foreach ( $pages as $page ) : ?>
+                                <option value="<?php echo esc_attr( $page->ID ); ?>" <?php selected( $s['review_page'], $page->ID ); ?>>
+                                    <?php echo esc_html( $page->post_title ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <p class="description"><?php esc_html_e( 'The customer is sent to this page to leave their review. Place [reviewfic_form] on it.', 'reviewfic' ); ?></p>
+                    </div>
+
+                    <div class="rwf-wc-field">
+                        <label><?php esc_html_e( 'Email Subject', 'reviewfic' ); ?></label>
+                        <input type="text" name="rwf_email_subject" value="<?php echo esc_attr( $s['email_subject'] ); ?>" class="large-text">
+                        <p class="description"><?php esc_html_e( 'Placeholders: {customer_name}, {order_id}, {site_name}', 'reviewfic' ); ?></p>
+                    </div>
+
+                    <div class="rwf-wc-field">
+                        <label><?php esc_html_e( 'Email Body', 'reviewfic' ); ?></label>
+                        <textarea name="rwf_email_body" rows="6" class="large-text"><?php echo esc_textarea( $s['email_body'] ); ?></textarea>
+                        <p class="description"><?php esc_html_e( 'Placeholders: {customer_name}, {order_id}, {site_name}. The review button is added automatically.', 'reviewfic' ); ?></p>
+                    </div>
+
+                    <div class="rwf-wc-preview-note">
+                        <span class="dashicons dashicons-visibility"></span>
+                        <?php esc_html_e( 'A styled "Leave a Review" button with your review page link is automatically appended to the email.', 'reviewfic' ); ?>
+                    </div>
+                </div>
+
+                <!-- ── Display & Tagging ── -->
+                <div>
+                    <div class="rwf-ie-card" style="margin-bottom:20px;">
+                        <div class="rwf-ie-card-header">
+                            <span class="dashicons dashicons-star-filled rwf-ie-card-icon"></span>
+                            <div>
+                                <h2><?php esc_html_e( 'Listing Review Section', 'reviewfic' ); ?></h2>
+                                <p><?php esc_html_e( 'Replace Tourfic\'s review section with Reviewfic\'s cards on hotel, tour, and apartment listings.', 'reviewfic' ); ?></p>
+                            </div>
+                        </div>
+                        <div class="rwf-wc-field">
+                            <label class="rwf-wc-toggle-label">
+                                <input type="checkbox" name="rwf_replace_section" value="1" <?php checked( $s['replace_section'], '1' ); ?>>
+                                <strong><?php esc_html_e( 'Replace the Tourfic review section', 'reviewfic' ); ?></strong>
+                            </label>
+                            <p class="description">
+                                <?php esc_html_e( 'Reviews will be rendered using Template 1 (Classic) with 3 columns. A "Write a Review" button links to your review landing page.', 'reviewfic' ); ?>
+                                <br><em><?php esc_html_e( 'Note: car rental listings use an embedded review block and are not affected by this setting.', 'reviewfic' ); ?></em>
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="rwf-ie-card">
+                        <div class="rwf-ie-card-header">
+                            <span class="dashicons dashicons-tag rwf-ie-card-icon"></span>
+                            <div>
+                                <h2><?php esc_html_e( 'Auto-Tag by Service', 'reviewfic' ); ?></h2>
+                                <p><?php esc_html_e( 'Automatically categorise reviews by the booked service when submitted via the review request link.', 'reviewfic' ); ?></p>
+                            </div>
+                        </div>
+                        <div class="rwf-wc-field">
+                            <label class="rwf-wc-toggle-label">
+                                <input type="checkbox" name="rwf_auto_tag" value="1" <?php checked( $s['auto_tag'], '1' ); ?>>
+                                <strong><?php esc_html_e( 'Auto-tag reviews with service name as category', 'reviewfic' ); ?></strong>
+                            </label>
+                            <p class="description"><?php esc_html_e( 'When a customer clicks the review link from the email and submits a review, it is automatically tagged with a prefixed category (e.g. "Hotel: Grand Hyatt", "Tour: Desert Safari").', 'reviewfic' ); ?></p>
+                        </div>
+                    </div>
+                </div>
+
+            </div><!-- .rwf-wc-grid -->
+
+            <p style="margin-top:20px;">
+                <button type="submit" class="button button-primary rwf-ie-btn">
+                    <?php esc_html_e( 'Save Tourfic Settings', 'reviewfic' ); ?>
+                </button>
+            </p>
+        </form>
+    </div>
+    <?php
+}
+
+
+// ══════════════════════════════════════════════════════════════════════════
+//  POST-BOOKING EMAIL
+// ══════════════════════════════════════════════════════════════════════════
+
+function rwf_tf_schedule_email( $order_id ) {
+    $s = rwf_tf_get_settings();
+    if ( $s['enabled'] !== '1' || empty( $s['review_page'] ) ) return;
+
+    // Only schedule for orders that contain a Tourfic booking
+    $order   = wc_get_order( $order_id );
+    if ( ! $order ) return;
+    $service = rwf_tf_get_service_from_order( $order );
+    if ( ! $service ) return;
+
+    $delay = max( 0, intval( $s['delay_days'] ) ) * DAY_IN_SECONDS;
+    wp_schedule_single_event( time() + $delay, 'reviewfic_send_tf_review_email', array( $order_id ) );
+}
+
+function rwf_tf_send_email( $order_id ) {
+    $order = wc_get_order( $order_id );
+    if ( ! $order ) return;
+
+    $s              = rwf_tf_get_settings();
+    $customer_name  = $order->get_billing_first_name();
+    $customer_email = $order->get_billing_email();
+    $order_number   = $order->get_order_number();
+    $site_name      = get_bloginfo( 'name' );
+    $review_page_id = intval( $s['review_page'] );
+
+    if ( ! $review_page_id || ! $customer_email ) return;
+
+    // Build review URL — include service ID + type for auto-tagging
+    $review_url = get_permalink( $review_page_id );
+    $service    = rwf_tf_get_service_from_order( $order );
+    if ( $service ) {
+        $review_url = add_query_arg( array(
+            'rwf_tf_service' => $service['post_id'],
+            'rwf_tf_type'    => $service['type'],
+        ), $review_url );
+    }
+    $review_url = add_query_arg( 'rwf_order', $order_id, $review_url );
+
+    // Subject
+    $subject = str_replace(
+        array( '{customer_name}', '{order_id}', '{site_name}' ),
+        array( $customer_name,    $order_number, $site_name   ),
+        $s['email_subject']
+    );
+
+    // Body
+    $body_text = str_replace(
+        array( '{customer_name}', '{order_id}', '{site_name}' ),
+        array( $customer_name,    $order_number, $site_name   ),
+        $s['email_body']
+    );
+
+    $html = rwf_tf_build_email_html( $body_text, $review_url, $site_name );
+
+    add_filter( 'wp_mail_content_type', 'rwf_set_html_mail_tf' );
+    wp_mail( $customer_email, $subject, $html );
+    remove_filter( 'wp_mail_content_type', 'rwf_set_html_mail_tf' );
+}
+
+function rwf_tf_build_email_html( $body_text, $review_url, $site_name ) {
+    $body_html = nl2br( esc_html( $body_text ) );
+    $btn_color = '#0E9F6E';
+
+    return '<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f3f4f6;padding:40px 0;">
+    <tr><td align="center">
+      <table width="580" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:12px;overflow:hidden;max-width:580px;width:100%;">
+
+        <!-- Header -->
+        <tr>
+          <td style="background:' . esc_attr( $btn_color ) . ';padding:24px 40px;text-align:center;">
+            <span style="color:#fff;font-size:20px;font-weight:700;">' . esc_html( $site_name ) . '</span>
+          </td>
+        </tr>
+
+        <!-- Body -->
+        <tr>
+          <td style="padding:36px 40px 28px;color:#374151;font-size:15px;line-height:1.7;">
+            <p style="margin:0 0 24px;">' . $body_html . '</p>
+
+            <!-- CTA Button -->
+            <table cellpadding="0" cellspacing="0" style="margin:28px 0;">
+              <tr>
+                <td style="background:' . esc_attr( $btn_color ) . ';border-radius:8px;padding:0;">
+                  <a href="' . esc_url( $review_url ) . '"
+                     style="display:inline-block;padding:14px 32px;color:#fff;text-decoration:none;font-size:15px;font-weight:700;border-radius:8px;">
+                    ⭐ Leave a Review
+                  </a>
+                </td>
+              </tr>
+            </table>
+
+            <p style="margin:0;font-size:13px;color:#9ca3af;">
+              If the button does not work, copy this link into your browser:<br>
+              <a href="' . esc_url( $review_url ) . '" style="color:' . esc_attr( $btn_color ) . ';word-break:break-all;">' . esc_html( $review_url ) . '</a>
+            </p>
+          </td>
+        </tr>
+
+        <!-- Footer -->
+        <tr>
+          <td style="background:#f9fafb;padding:20px 40px;text-align:center;font-size:12px;color:#9ca3af;border-top:1px solid #f3f4f6;">
+            &copy; ' . esc_html( date( 'Y' ) ) . ' ' . esc_html( $site_name ) . '. Powered by <a href="https://wordpress.org/plugins/reviewfic/" style="color:#9ca3af;">Reviewfic</a>.
+          </td>
+        </tr>
+
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>';
+}
+
+
+// ══════════════════════════════════════════════════════════════════════════
+//  REVIEW SECTION REPLACEMENT
+// ══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Intercept the comments_template filter at priority 20 (after Tourfic's priority 10).
+ * Only active for tf_hotel, tf_tours, tf_apartment — car rental is not supported.
+ */
+function rwf_tf_replace_comments_template( $template ) {
+    $s = rwf_tf_get_settings();
+    if ( $s['replace_section'] !== '1' ) return $template;
+
+    global $post;
+    if ( ! $post ) return $template;
+
+    $supported_types = array( 'tf_hotel', 'tf_tours', 'tf_apartment' );
+    if ( ! in_array( $post->post_type, $supported_types, true ) ) return $template;
+
+    $our_template = plugin_dir_path( __FILE__ ) . 'templates/tourfic-reviews.php';
+    if ( file_exists( $our_template ) ) {
+        return $our_template;
+    }
+
+    return $template;
+}
+
+
+// ══════════════════════════════════════════════════════════════════════════
+//  AUTO-TAG BY SERVICE
+// ══════════════════════════════════════════════════════════════════════════
+
+function rwf_tf_auto_tag_service( $post_id, $post_data ) {
+    $s = rwf_tf_get_settings();
+    if ( $s['auto_tag'] !== '1' ) return;
+
+    $service_id = intval( $post_data['rwf_tf_service_id'] ?? 0 );
+    $type       = sanitize_key( $post_data['rwf_tf_type'] ?? '' );
+    if ( ! $service_id || ! $type ) return;
+
+    $service_post = get_post( $service_id );
+    if ( ! $service_post ) return;
+
+    $type_label  = rwf_tf_type_label( $type );
+    $term_name   = $type_label . ': ' . $service_post->post_title;
+    $term        = get_term_by( 'name', $term_name, 'reviewfic_category' );
+
+    if ( ! $term ) {
+        $result  = wp_insert_term( $term_name, 'reviewfic_category' );
+        $term_id = ! is_wp_error( $result ) ? $result['term_id'] : 0;
+    } else {
+        $term_id = $term->term_id;
+    }
+
+    if ( $term_id ) {
+        wp_set_post_terms( $post_id, array( $term_id ), 'reviewfic_category', true );
+    }
+}

--- a/reviewfic.php
+++ b/reviewfic.php
@@ -3,7 +3,7 @@
 Plugin Name: Reviewfic – Testimonial Slider, Testimonial Grid & Customer Reviews
 Plugin URI: https://themefic.com/reviewfic/
 Description: A plugin to create and manage client reviews with custom post types and shortcodes.
-Version: 1.2.36
+Version: 1.2.37
 Author: Themefic
 Author URI: https://themefic.com
 Text Domain: reviewfic
@@ -79,9 +79,10 @@ function reviewfic_admin_enqueue($hook) {
     $on_our_plugins   = $hook === 'reviewfic_reviews_page_reviewfic-our-plugins';
     $on_live_reviews  = $hook === 'reviewfic_reviews_page_reviewfic-live-reviews';
     $on_woocommerce   = $hook === 'reviewfic_reviews_page_reviewfic-woocommerce';
+    $on_tourfic       = $hook === 'reviewfic_reviews_page_reviewfic-tourfic';
 
     // Load admin CSS on review edits, config edits, and import/export page
-    if (($on_review_edit || $on_config_edit || $on_import_export || $on_integrations || $on_get_help || $on_our_plugins || $on_live_reviews || $on_woocommerce) && file_exists($admin_css_file)) {
+    if (($on_review_edit || $on_config_edit || $on_import_export || $on_integrations || $on_get_help || $on_our_plugins || $on_live_reviews || $on_woocommerce || $on_tourfic) && file_exists($admin_css_file)) {
         wp_enqueue_style(
             'reviewfic-admin-style',
             plugin_dir_url(__FILE__) . 'assets/css/reviewfic-admin.css',
@@ -129,6 +130,7 @@ require_once plugin_dir_path(__FILE__) . 'admin/import-export.php';
 require_once plugin_dir_path(__FILE__) . 'admin/extra-pages.php';
 require_once plugin_dir_path(__FILE__) . 'admin/live-reviews.php';
 require_once plugin_dir_path(__FILE__) . 'admin/woocommerce.php';
+require_once plugin_dir_path(__FILE__) . 'admin/tourfic.php';
 require_once plugin_dir_path(__FILE__) . 'admin/form-integrations.php';
 // ── Submenu reorder ────────────────────────────────────────────────────────
 // Runs last so all submenus are registered before we sort.
@@ -149,6 +151,7 @@ add_action( 'admin_menu', function () {
         'reviewfic-integrations',
         'reviewfic-import-export',
         'reviewfic-woocommerce',
+        'reviewfic-tourfic',
     );
     $pinned_last = array( 'reviewfic-get-help', 'reviewfic-our-plugins' );
 


### PR DESCRIPTION
- New admin/tourfic.php: post-booking email scheduling (configurable delay), comments_template replacement at priority 20, auto-tag by service name (Hotel / Tour / Apartment / Car prefix)
- New admin/templates/tourfic-reviews.php: renders Reviewfic cards from Tourfic comment meta; averages tf_comment_meta sub-ratings; Write a Review CTA with rwf_tf_service query args
- admin/review-form.php: carry rwf_tf_service_id + rwf_tf_type hidden fields through form submission (mirrors rwf_product_id pattern)
- admin/form-integrations.php: Tourfic tab in nav + summary card
- reviewfic.php: require tourfic.php, CSS hook, submenu order, v1.2.37

Note: car rental review section replacement unsupported (Tourfic embeds review block directly; no comments_template() call).